### PR TITLE
BC-8267 - aktivate for dev thr only the one mongo cluster for all mode

### DIFF
--- a/ansible/roles/tldraw-server/tasks/main.yml
+++ b/ansible/roles/tldraw-server/tasks/main.yml
@@ -1,3 +1,17 @@
+  - name: External Secret for TlDraw Server
+    kubernetes.core.k8s:
+      kubeconfig: ~/.kube/config
+      namespace: "{{ NAMESPACE }}"
+      template: tldraw-server-external-secret.yml.j2
+      state: "{{ 'present' if 
+               WITH_BRANCH_MONGO_DB_MANAGEMENT is defined and WITH_BRANCH_MONGO_DB_MANAGEMENT|bool and
+               WITH_TLDRAW2 is defined and WITH_TLDRAW2|bool
+               else 'absent'}}"
+    when:
+     - EXTERNAL_SECRETS_OPERATOR is defined and EXTERNAL_SECRETS_OPERATOR|bool
+    tags:
+     - 1password
+
   - name: TlDraw server Secret (from 1Password)
     kubernetes.core.k8s:
       kubeconfig: ~/.kube/config

--- a/ansible/roles/tldraw-server/templates/onepassword.yml.j2
+++ b/ansible/roles/tldraw-server/templates/onepassword.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
-  name: tldraw-server-secret
+  name: tldraw-server-secret{{ EXTERNAL_SECRETS_POSTFIX }}
   namespace: {{ NAMESPACE }}
   labels:
     app: tldraw-server

--- a/ansible/roles/tldraw-server/templates/tldraw-server-external-secret.yml.j2
+++ b/ansible/roles/tldraw-server/templates/tldraw-server-external-secret.yml.j2
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: tldraw-server-secret
+  namespace: {{ NAMESPACE }}
+  labels:
+    app: tldraw-server
+spec:
+  refreshInterval: {{ EXTERNAL_SECRETS_REFRESH_INTERVAL }}
+  secretStoreRef:
+    kind: SecretStore
+    name: {{ EXTERNAL_SECRETS_K8S_STORE }}
+  target:
+    name: tldraw-server-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      data:
+        TLDRAW_DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'tldraw' ~ MONGO_MANAGEMENT_POSTFIX }}"
+  dataFrom:
+  - extract:
+      key: tldraw-server-secret{{ EXTERNAL_SECRETS_POSTFIX }}
+  data:
+  - secretKey: MONGO_MANAGEMENT_TEMPLATE_URL
+    remoteRef:
+      key: mongo-cluster-readwrite-secret
+      property: credentials-url


### PR DESCRIPTION
# Description
To reduce the trouble by the lag of the nfs PVCs and mongo DB on dev thr we activate for dev THR the mode to use one mongodb replicaset for all.
Additionaly the ExternalSecret Kubernetes Object was add to the tldraw server repo

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/BC-8267
- hpi-schul-cloud/schulcloud-server#5298
- hpi-schul-cloud/dof_app_deploy#998

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
